### PR TITLE
Removing references to calendar in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
 # Purpose
-This application checks the [Flying Pie website](http://www.flyingpie.com/its-your-day.htm) for their latest "**It's Your Day**" names. It updates a Google calendar with the names of the lucky people for each day and sends email notifications when new names are added.
+This application checks the [Flying Pie website](http://www.flyingpie.com/its-your-day.htm) for their latest "**It's Your Day**" names, and sends email notifications when any changes are made to the list.
 
 # Setup
-I recommend creating a new Google account for this so that if something goes horribly wrong with the calendar synchronization process, your real account will be unharmed. Follow [Google's guide](https://developers.google.com/api-client-library/dotnet/get_started) to visit the Developers Console and create an OAuth client ID for your account. You'll need to download the client\_secret.json file and put it in the root of your copy of this repo. You'll also want to create an [app-specific password](https://security.google.com/settings/security/apppasswords) for this application. 
+I recommend creating a new Google account for this so that if anything goes horribly wrong, your real account will be unharmed. Then set up an [app-specific password](https://security.google.com/settings/security/apppasswords) for this application so it can send emails.
 
-Next, copy the FlyingPie\_example.config as FlyingPie.config and replace the sample values with your own.
+Next, copy the file FlyingPie\_example.config as FlyingPie.config and replace the sample values with your own.
 
  - FromEmailAddress is the email address of the account you made for this.
  - ErrorEmails is a comma-separated list of email addresses which should be notified if something goes wrong.
  - UpdateEmails is a comma-separated list of email addresses which will be notified when new IYD names are posted.
  - SaltyString should be a long string of random characters. It's used to help encrypt the password for your email account.
 
-Now you should be ready to build and run the application. The first time you start, it will ask for the app-specific password you set up earlier. This password will be encrypted using Windows' DPAPI so it should only be able to be decrypted by the currently-logged-in user: you should have a strong password on your Windows account! The encrypted password is saved in the app.config so that when this application runs in the future, it won't have to prompt you for the password.
-
-Then the application will open a browser window to prompt you for access to your Google calendar. Ensure that you're logged in as the account you created for this when you do. Once that's done, the app should silently continue on to run a check for new IYD events, then exit. Future calls to this application from the same user should be quick and painless, requiring no user input.
+Now you should be ready to build and run the application. The first time you start, it will ask for the app-specific password you set up earlier. This password will be encrypted using Windows' DPAPI so it should only be able to be decrypted by the currently-logged-in user: you should have a strong password on your Windows account! The encrypted password is saved in the app.config so that when this application runs in the future, it won't have to prompt you for the password. Once that's done, the app should silently continue on to run a check for new IYD events, then exit. Future calls to this application from the same user should be quick and painless, requiring no user input.


### PR DESCRIPTION
They've removed actual dates from their website, making it much more difficult to determine what day they're talking about when things change. Now if the "Monday" line is updated, did they mean that change for the current week or the next? Did they just fix a typo or decide to change the name for the current Monday, or is this an update for the next Monday?

I've decided this is too much hassle to deal with, so I'm going to remove the calendaring portion of this program and just have it email diffs when the text changes - maybe the humans receiving the emails will be able to figure out which day they're talking about.